### PR TITLE
Remove "REM " after //

### DIFF
--- a/Duckyspark_translator.py
+++ b/Duckyspark_translator.py
@@ -197,7 +197,7 @@ for i in range(z):
 	else:
 
 		if 'REM' in l:
-			print ('//', l)	
+			print ('//', l.replace('REM ', ''))	
 		
 		else:
 			if 'DELAY' in l:


### PR DESCRIPTION
You forgot to remove the "REM " at the beginning of comments.
"REM Hello World" would become "//REM Hello World" not "//Hello World"